### PR TITLE
Emit errors when install_requires not recognised

### DIFF
--- a/flake8_exact_pin.py
+++ b/flake8_exact_pin.py
@@ -26,7 +26,7 @@ class ExactPinChecker(object):
                 noqa = get_noqa_lines(file_to_check.readlines())
 
         if os.path.basename(self.filename) == 'setup.py':
-            errors = check_tree_for_print_statements(self.tree, noqa)
+            errors = pinned_install_requires(self.tree, noqa)
 
             for error in errors:
                 yield (
@@ -43,12 +43,31 @@ def get_noqa_lines(code):
     return noqa
 
 
-def check_tree_for_print_statements(tree, noqa):
+def pinned_install_requires(tree, noqa):
     errors = []
+    setup_node = None
 
     for node in ast.walk(tree):
         if isinstance(node, ast.keyword) and node.arg == 'install_requires':
+            try:
+                node.value.elts
+            except AttributeError:
+                errors.append({
+                    'message': 'P100 Unrecognised install_requires value',
+                    'line': node.lineno,
+                    'col': node.col_offset,
+                })
+                return errors
+
             for str_node in node.value.elts:
+                if not isinstance(str_node, ast.Str):
+                    errors.append({
+                        'message': 'P101 Unrecognised install_requires item',
+                        'line': str_node.lineno,
+                        'col': str_node.col_offset,
+                    })
+                    continue
+
                 requirement = str_node.s
                 if '==' in requirement:
                     errors.append({
@@ -58,5 +77,25 @@ def check_tree_for_print_statements(tree, noqa):
                         'line': str_node.lineno,
                         'col': str_node.col_offset,
                     })
+            break
+        elif isinstance(node, ast.Call):
+            try:
+                if node.func.id == 'setup':
+                    setup_node = node
+            except:
+                pass
+    else:
+        if setup_node:
+            errors.append({
+                'message': 'P103 Missing install_requires in setup(..)',
+                'line': setup_node.lineno,
+                'col': setup_node.col_offset,
+            })
+        else:
+            errors.append({
+                'message': 'P104 Missing setup()',
+                'line': 0,
+                'col': 0,
+            })
 
     return errors


### PR DESCRIPTION
When the install_requires value is not comprised of a list
containing strings, flake8-exact-pin raises AttributeError.

Add codes P100-4 to report various detection issues.
