### PR TITLE
Fix extension registration in entry_points.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=['setuptools'],
     entry_points={
         'flake8.extension': [
-            'flake8_exact_pin = flake8_exact_pin:ExactPinChecker'
+            'P = flake8_exact_pin:ExactPinChecker'
         ],
     },
     url='https://github.com/msabramo/flake8-exact-pin',


### PR DESCRIPTION
Not sure if this used to work differently in older versions of flake8,
but the current version won't report any of the issues without this
change.

Relevant docs at http://flake8.pycqa.org/en/latest/plugin-development/registering-plugins.html