### PR TITLE
Exclude environment markers from version checks.

### DIFF
--- a/flake8_exact_pin.py
+++ b/flake8_exact_pin.py
@@ -68,7 +68,7 @@ def pinned_install_requires(tree, noqa):
                     })
                     continue
 
-                requirement = str_node.s
+                requirement = str_node.s.split(';', 1)[0]
                 if '==' in requirement:
                     errors.append({
                         'message': '{0} {1}: "{2}"'.format(


### PR DESCRIPTION
This is to prevent something like the following from failing: "backports.csv>=1.0.5,<2 ; python_version == '2.7'"